### PR TITLE
fix: CI/CD 배포 ESM 설정 수정

### DIFF
--- a/10week/src/modules/mission/services/mission.service.ts
+++ b/10week/src/modules/mission/services/mission.service.ts
@@ -4,9 +4,9 @@
  * - 전역 에러 미들웨어가 자동으로 FAIL 봉투로 변환해줌
  */
 
-import { addMission, getUserMission, addUserMission } from "../repositories/mission.repository";
-import { getStoreById } from "../../store/repositories/store.repository";
-import { MissionAddRequest } from "../dtos/mission.dtos";
+import { addMission, getUserMission, addUserMission } from "../repositories/mission.repository.js";
+import { getStoreById } from "../../store/repositories/store.repository.js";
+import { MissionAddRequest } from "../dtos/mission.dtos.js";
 import {
   StoreNotFoundError,
   AlreadyChallengingMissionError,

--- a/10week/tsoa.json
+++ b/10week/tsoa.json
@@ -8,6 +8,7 @@
     "basePath": "/api/v1"
   },
   "routes": {
-    "routesDir": "src/generated"
+    "routesDir": "src/generated",
+    "esm": true
   }
 }


### PR DESCRIPTION
## 작업 내용

- 배포 환경에서 Prisma 생성 파일을 실행할 수 있도록 package.json을 ESM 설정으로 수정했습니다.
- tsoa routes 생성 시 ESM import 경로가 생성되도록 설정했습니다.
- mission service의 상대 import 경로에 .js 확장자를 추가했습니다.

## 확인 사항

- GitHub Actions deploy-main 재실행 후 배포 확인 예정