### PR TITLE
✨ FEATURE: [Chapter 10] CI/CD 배포 자동화 (GitHub Actions + AWS EC2)

### DIFF
--- a/10week/src/auth.config.ts
+++ b/10week/src/auth.config.ts
@@ -126,7 +126,9 @@ export const googleStrategy = new GoogleStrategy(
     clientSecret: process.env.PASSPORT_GOOGLE_CLIENT_SECRET!,
 
     // Google Cloud의 승인된 리디렉션 URI와 정확히 같아야 한다.
-    callbackURL: "http://localhost:3000/oauth2/callback/google",
+    callbackURL:
+      process.env.PASSPORT_GOOGLE_CALLBACK_URL ||
+      "http://localhost:3000/oauth2/callback/google",
 
     // Google에서 받아올 사용자 정보 범위
     scope: ["email", "profile"],


### PR DESCRIPTION
## 📌 개요 (What & Why?)
- GitHub Actions와 AWS EC2를 이용해 main 브랜치 기준 CI/CD 배포 파이프라인을 구축했습니다.
- EC2 배포 환경에서 Google OAuth 로그인이 동작하지 않는 원인을 확인하고, callback URL을 환경변수로 분리했습니다.
- 배포 환경에서는 localhost가 아닌 실제 서버 주소 또는 도메인을 사용해야 하므로, 추후 도메인 연결 시 바로 적용할 수 있도록 수정했습니다.

## 📦 영향 범위 (Scope)
- [x] API 추가
- [ ] UI 변경
- [x] DB 변경
- [x] 기타

## 🧩 변경 방식 (How?)
- `.github/workflows/deploy-main.yml`을 추가하여 GitHub Actions 기반 배포 파이프라인을 구성했습니다.
- `main` 브랜치에 merge되면 프로젝트를 빌드하고 EC2 서버로 artifact를 전송한 뒤 systemd 서비스를 재시작하도록 설정했습니다.
- EC2 내부에 Node.js, MySQL 배포 환경을 구성하고 `umc_10th` 데이터베이스를 생성했습니다.
- `package.json`, `tsoa.json`, 일부 import 경로를 수정하여 EC2 배포 환경에서 정상 빌드 및 실행되도록 수정했습니다.
- Google OAuth callback URL을 `PASSPORT_GOOGLE_CALLBACK_URL` 환경변수로 관리하도록 변경했습니다.

## ✅ TODO
- [x] CI/CD 파이프라인 구현
- [x] EC2 배포 환경 구성
- [x] MySQL 데이터베이스 생성
- [x] GitHub Actions Secrets 설정
- [x] 배포 서버 실행 확인
- [x] Google OAuth 배포 환경 문제 원인 확인
- [x] callback URL 환경변수 분리
- [ ] 도메인 연결 후 Google OAuth 최종 동작 확인

## 🧪 테스트 계획 (Test Plan)
- [x] GitHub Actions build/deploy 성공 확인
- [x] EC2 systemd 서비스 실행 상태 확인
- [x] EC2 퍼블릭 주소로 서버 접속 확인
- [x] Swagger 문서 접속 확인
- [x] Google OAuth callback URL 문제 확인

Closes #25 